### PR TITLE
Updated page spawn to top and enabled overflow (scrolling)

### DIFF
--- a/index.scss
+++ b/index.scss
@@ -8,6 +8,9 @@ body {
   align-items: center;
   display: flex;
   justify-content: center;
+  flex-direction: column;  
+  justify-content: flex-start;
+  overflow-y: auto;   
 
   background: linear-gradient(to bottom right, #444444, #009a5b);
   font-size: 1.0rem;

--- a/index.scss
+++ b/index.scss
@@ -7,7 +7,6 @@ body {
 body {
   align-items: center;
   display: flex;
-  justify-content: center;
   flex-direction: column;  
   justify-content: flex-start;
   overflow-y: auto;   


### PR DESCRIPTION
When loading the xs-plotter. If my screen was zoomed in the top of the webpage would be cropped.

Exploring the code I found the spawning was focusing on the centre of the screen with no overflow at the top for scrolling. I adjusted to spawn at the top of the screen and enable full scroll. 

Jon, check this fits with your wider style ambitions. Hopefully just a minor quality of life adjustment.