### PR TITLE
Making all table headers inline

### DIFF
--- a/index.scss
+++ b/index.scss
@@ -40,3 +40,13 @@ h1 + .subtitle {
   width: 100%;
   height: 100%;
 }
+
+th.user-select-none > span {    
+  display: inline-flex;          
+  align-items: center;           
+  white-space: nowrap;            
+}
+
+th.user-select-none i.fa-solid {   
+  margin-left: .35rem;          
+}


### PR DESCRIPTION
In my webpage the table headers were pushed on to two lines: 
<img width="438" alt="2lines" src="https://github.com/user-attachments/assets/a0bc6856-4131-4e61-9815-79cfb4771170" />


Slight adjustment to make them inline: 
<img width="447" alt="1line" src="https://github.com/user-attachments/assets/f2020c77-5cb8-4439-80ac-f10427bab829" />

