### PR TITLE
Prevent background colour from cropping

### DIFF
--- a/index.scss
+++ b/index.scss
@@ -1,6 +1,8 @@
-html,
+html { 
+  min-height: 100%;
+}
+
 body {
-  height: 100%;
   margin: 0;
 }
 
@@ -10,7 +12,7 @@ body {
   flex-direction: column;  
   justify-content: flex-start;
   overflow-y: auto;   
-
+    
   background: linear-gradient(to bottom right, #444444, #009a5b);
   font-size: 1.0rem;
 }


### PR DESCRIPTION
When I was using the app I spotted when you zoom our or scroll down sometimes the background colour cuts out: 
<img width="1296" height="75" alt="cropped_background" src="https://github.com/user-attachments/assets/c7edaa26-11d0-43b2-9ddf-bbe631756030" />


I made minor tweaks so that the background colour keeps running, irrespective of height by setting min-height.
<img width="1342" height="110" alt="uncropped_background" src="https://github.com/user-attachments/assets/2a64aa1c-704d-4bec-8944-ebfe7aa15f2c" />
